### PR TITLE
FileSystem: Add Operations::getCurrentDirectory

### DIFF
--- a/Libraries/FileSystem/FileSystem.h
+++ b/Libraries/FileSystem/FileSystem.h
@@ -325,6 +325,7 @@ struct SC_COMPILER_EXPORT FileSystem
         static Result setLastModifiedTime(StringSpan path, Time::Realtime time);
 
         static StringSpan getExecutablePath(StringPath& executablePath);
+        static StringSpan getCurrentWorkingDirectory(StringPath& currentWorkingDirectory);
         static StringSpan getApplicationRootDirectory(StringPath& applicationRootDirectory);
 
       private:

--- a/Tests/Libraries/FileSystem/FileSystemTest.cpp
+++ b/Tests/Libraries/FileSystem/FileSystemTest.cpp
@@ -58,6 +58,12 @@ struct SC::FileSystemTest : public SC::TestCase
             report.console.print("applicationRootDirectory=\"{}\"\n",
                                  FileSystem::Operations::getApplicationRootDirectory(stringPath));
         }
+        if (test_section("getCurrentWorkingDirectory"))
+        {
+            StringPath stringPath;
+            report.console.print("currentWorkingDirectory=\"{}\"\n",
+                FileSystem::Operations::getCurrentWorkingDirectory(stringPath));
+        }
         // TODO: Add tests for createSymbolicLink, existsAndIsLink, removeLinkIfExists and moveDirectory
     }
 


### PR DESCRIPTION
This PR implements `FileSystem::Operations::getCurrentWorkingDirectory` as we discussed privately, which is necessary given `FileDescriptor::open` requires absolute paths. I also wrote a very light-weight test similar to the ones for getExecutablePath and verified the outputs on Windows and Linux (WSL2).