### PR TITLE
Trigger "Documentation and Code Coverage" workflow on PR

### DIFF
--- a/.github/workflows/documentation_coverage.yml
+++ b/.github/workflows/documentation_coverage.yml
@@ -1,9 +1,10 @@
-# Simple workflow for deploying static content to GitHub Pages
 name: Documentation and Code Coverage
 
 on:
-  # Runs on pushes targeting main and development branch
+  # Runs on pushes and pull requests targeting the main branch
   push:
+    branches: [ "main" ]
+  pull_request:
     branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/Libraries/FileSystem/FileSystem.cpp
+++ b/Libraries/FileSystem/FileSystem.cpp
@@ -937,8 +937,8 @@ SC::StringSpan SC::FileSystem::Operations::getApplicationRootDirectory(StringPat
 #include <sys/attr.h>
 #include <sys/clonefile.h>
 #elif SC_PLATFORM_LINUX
-#include <sys/syscall.h> // SYS_getcwd
 #include <sys/sendfile.h>
+#include <sys/syscall.h> // SYS_getcwd
 #endif
 struct SC::FileSystem::Operations::Internal
 {

--- a/Tests/Libraries/FileSystem/FileSystemTest.cpp
+++ b/Tests/Libraries/FileSystem/FileSystemTest.cpp
@@ -62,7 +62,7 @@ struct SC::FileSystemTest : public SC::TestCase
         {
             StringPath stringPath;
             report.console.print("currentWorkingDirectory=\"{}\"\n",
-                FileSystem::Operations::getCurrentWorkingDirectory(stringPath));
+                                 FileSystem::Operations::getCurrentWorkingDirectory(stringPath));
         }
         // TODO: Add tests for createSymbolicLink, existsAndIsLink, removeLinkIfExists and moveDirectory
     }


### PR DESCRIPTION
The clang-format workflow did not trigger during my last PR, so these commits fix the formatting and add the trigger to that workflow.