### PR TITLE
Move website publishing to Astro source repo

### DIFF
--- a/.github/workflows/documentation_coverage.yml
+++ b/.github/workflows/documentation_coverage.yml
@@ -12,17 +12,12 @@ env:
   CC: clang
   CXX: clang++
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   actions: read
   contents: read
-  pages: write
-  id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: "documentation-coverage-${{ github.ref }}"
   cancel-in-progress: false
 
 jobs:
@@ -112,36 +107,12 @@ jobs:
       with:
         path: _Build/_PackagesCache/doxygen-awesome-css
         key: ${{ steps.doxygen-awesome-css-cache.outputs.cache-primary-key }}
-    - name: Setup Pages
-      # Skip documentation deployment step on forks
-      # This may fail because forks may not have enabled pages.
-      # Probably a better way to handle this would be by using a CI variable.
-      if: github.ref == 'refs/heads/main' && github.repository == 'Pagghiu/SaneCppLibraries'
-      uses: actions/configure-pages@v4
-    - name: Upload Artifact
-      if: github.ref == 'refs/heads/main' && github.repository == 'Pagghiu/SaneCppLibraries'
-      uses: actions/upload-pages-artifact@v3
+    - name: Upload documentation artifact
+      if: always() && hashFiles('_Build/_Documentation/docs/**') != ''
+      uses: actions/upload-artifact@v4
       with:
-        # location of the coverage artifacts
+        name: sane-cpp-documentation
         path: "_Build/_Documentation/docs"
-
-  deploy:
-    if: github.ref == 'refs/heads/main' && github.repository == 'Pagghiu/SaneCppLibraries'
-    runs-on: ubuntu-latest
-    needs: build
-
-    permissions:
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
 
   timing-summary:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger_website_publish.yml
+++ b/.github/workflows/trigger_website_publish.yml
@@ -1,0 +1,25 @@
+name: Trigger website publish
+
+on:
+  workflow_run:
+    workflows: ["Documentation and Code Coverage"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: github.event.workflow_run.conclusion == 'success' && github.repository == 'Pagghiu/SaneCppLibraries'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Astro website publish
+        env:
+          GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+          SANE_CPP_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          gh api repos/Pagghiu/pagghiu.github.io-source/dispatches \
+            -f event_type=sane-cpp-main-updated \
+            -f client_payload[sha]="$SANE_CPP_SHA"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Windows](https://github.com/Pagghiu/SaneCppLibraries/actions/workflows/windows.yml/badge.svg)](https://github.com/Pagghiu/SaneCppLibraries/actions/workflows/windows.yml)
 [![Linux+macOS](https://github.com/Pagghiu/SaneCppLibraries/actions/workflows/posix.yml/badge.svg)](https://github.com/Pagghiu/SaneCppLibraries/actions/workflows/posix.yml)
-[![Coverage](https://pagghiu.github.io/SaneCppLibraries/coverage/coverage.svg)](https://pagghiu.github.io/SaneCppLibraries/coverage)
+[![Coverage](https://pagghiu.github.io/SaneCppLibraries/reference/doxygen/coverage/coverage.svg)](https://pagghiu.github.io/SaneCppLibraries/reference/doxygen/coverage/)
 
 # Sane C++ Libraries
 
@@ -9,127 +9,188 @@
 [![Discord](https://img.shields.io/discord/1195076118307426384)](https://discord.gg/tyBfFp33Z6)
 ![GitHub Repo stars](https://img.shields.io/github/stars/Pagghiu/SaneCppLibraries)
 
-**Sane C++ Libraries** is a set of C++ platform abstraction libraries for macOS, Windows and Linux.
+**Sane C++ Libraries** is a set of small C++ platform abstraction libraries for macOS, Windows, and Linux.
 
-[Principles](https://pagghiu.github.io/SaneCppLibraries/page_principles.html):  
-✅ Fast compile times  
-✅ Bloat free  
-✅ Simple and readable code  
-✅ Easy to integrate  
-⛔️ No C++ Standard Library / Exceptions / RTTI  
-⛔️ No third party build dependencies (prefer OS API)
+The project is designed around explicit APIs, low dependency pressure, single-file integration, and code that can be safely maintained with coding agents.
 
-## [Libraries](https://pagghiu.github.io/SaneCppLibraries/libraries.html)
+## Quick links
 
-Libraries are designed to be used as [Single File Libraries](https://pagghiu.github.io/SaneCppLibraries/page_single_file_libs.html) with minimal [dependencies](https://pagghiu.github.io/SaneCppLibraries/page_dependencies.html) between them and follow a strict **No Allocations** (*) policy.
+- [Website](https://pagghiu.github.io/SaneCppLibraries/)
+- [Library catalog](https://pagghiu.github.io/SaneCppLibraries/libraries/)
+- [Guides](https://pagghiu.github.io/SaneCppLibraries/guides/)
+- [Reference documentation](https://pagghiu.github.io/SaneCppLibraries/reference/doxygen/)
+- [Contributing](CONTRIBUTING.md)
+- [Blog](https://pagghiu.github.io)
 
-Library                                                                                                         | Description                                                               | Single File                                                                                                       
-:---------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------
-[Async](https://pagghiu.github.io/SaneCppLibraries/library_async.html)                                          | 🟨 Async I/O (files, sockets, timers, processes, fs events, tasks)        | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppAsync.h)                   
-[Async Streams](https://pagghiu.github.io/SaneCppLibraries/library_async_streams.html)                          | 🟨 Concurrently read, write and transform byte streams                    | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppAsyncStreams.h)            
-[Await](https://pagghiu.github.io/SaneCppLibraries/library_await.html)                                          | 🟨 C++20 coroutine layer over Async                                       | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppAwait.h)
-[Containers](https://pagghiu.github.io/SaneCppLibraries/library_containers.html)                                | 🟨 Generic containers (SC::Vector, SC::SmallVector, SC::Array)            | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppContainers.h)              
-[Containers Reflection](https://pagghiu.github.io/SaneCppLibraries/library_containers_reflection.html)          | 🟨 Containers specializations for Reflection and Serialization            | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppContainersReflection.h) 
-[File](https://pagghiu.github.io/SaneCppLibraries/library_file.html)                                            | 🟩 Synchronous Disk File I/O                                              | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppFile.h)                    
-[File System](https://pagghiu.github.io/SaneCppLibraries/library_file_system.html)                              | 🟩 File System operations (like copy / delete) for files / dirs           | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppFileSystem.h)              
-[File System Iterator](https://pagghiu.github.io/SaneCppLibraries/library_file_system_iterator.html)            | 🟩 Enumerates files and directories inside a given path                   | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppFileSystemIterator.h)      
-[File System Watcher](https://pagghiu.github.io/SaneCppLibraries/library_file_system_watcher.html)              | 🟩 Notifications {add,remove,rename,modify} for files / dirs              | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppFileSystemWatcher.h)       
-[Foundation](https://pagghiu.github.io/SaneCppLibraries/library_foundation.html)                                | 🟩 Primitive types, asserts, macros, Function, Span, Result               | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppFoundation.h)              
-[Hashing](https://pagghiu.github.io/SaneCppLibraries/library_hashing.html)                                      | 🟩 Compute `MD5`, `SHA1` or `SHA256` hashes for bytes streams             | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppHashing.h)                 
-[Http](https://pagghiu.github.io/SaneCppLibraries/library_http.html)                                            | 🟥 HTTP parser, client and server                                         | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppHttp.h)                    
-[Http Client](https://pagghiu.github.io/SaneCppLibraries/library_http_client.html)                              | 🟥 Streaming-first HTTP client with native OS backends                    | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppHttpClient.h)
-[Memory](https://pagghiu.github.io/SaneCppLibraries/library_memory.html)                                        | 🟩 Custom allocators, Virtual Memory, Buffer, Segment                     | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppMemory.h)                  
-[Plugin](https://pagghiu.github.io/SaneCppLibraries/library_plugin.html)                                        | 🟨 Minimal dependency based plugin system with hot-reload                 | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppPlugin.h)                  
-[Process](https://pagghiu.github.io/SaneCppLibraries/library_process.html)                                      | 🟩 Create child processes and redirect their input / output               | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppProcess.h)                 
-[Reflection](https://pagghiu.github.io/SaneCppLibraries/library_reflection.html)                                | 🟩 Describe C++ types at compile time for serialization                   | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppReflection.h)              
-[SerialPort](https://pagghiu.github.io/SaneCppLibraries/library_serial_port.html)                               | 🟨 Serial port configuration and handling                                 | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppSerialPort.h)                  
-[Serialization Binary](https://pagghiu.github.io/SaneCppLibraries/library_serialization_binary.html)            | 🟨 Serialize to and from a binary format using Reflection                 | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppSerializationBinary.h)     
-[Serialization Text](https://pagghiu.github.io/SaneCppLibraries/library_serialization_text.html)                | 🟨 Serialize to / from text formats (JSON) using Reflection               | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppSerializationText.h)       
-[Socket](https://pagghiu.github.io/SaneCppLibraries/library_socket.html)                                        | 🟨 Synchronous socket networking and DNS lookup                           | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppSocket.h)                  
-[Strings](https://pagghiu.github.io/SaneCppLibraries/library_strings.html)                                      | 🟩 String formatting / conversion / manipulation (UTF8 / UTF16)           | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppStrings.h)                 
-[Testing](https://pagghiu.github.io/SaneCppLibraries/library_testing.html)                                      | 🟨 Simple testing framework used by all of the other libraries            | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppTesting.h)                 
-[Threading](https://pagghiu.github.io/SaneCppLibraries/library_threading.html)                                  | 🟩 Atomic, thread, mutex, semaphore, barrier, rw-lock, condition          | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppThreading.h)               
-[Time](https://pagghiu.github.io/SaneCppLibraries/library_time.html)                                            | 🟨 Time handling (relative, absolute, high resolution)                    | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppTime.h)                    
+## Principles
 
-Each library is color-coded to signal its status:  
-🟥 Draft (incomplete, WIP, works on basic test cases)  
-🟨 MVP (a minimum set of features has been implemented)  
-🟩 Usable (a reasonable set of useful features has been implemented)  
+The full project principles are documented here:
+[Principles](https://pagghiu.github.io/SaneCppLibraries/guides/principles/).
+
+In short:
+
+- Fast compile times
+- Bloat-free code
+- Simple and readable implementation
+- Easy integration
+- Minimal dependencies between libraries
+- No hidden allocations in normal library code
+- No third-party build dependencies when an operating-system API can be wrapped directly
+
+## Agentic development model
+
+Sane C++ Libraries is now maintained primarily through agentic development.
+
+For contributors, this means a useful issue can be the whole contribution. The preferred workflow is to describe the desired change, the affected library or platform, the constraints, and the expected validation. A reusable prompt is welcome when it helps the maintainer replay or adapt the work.
+
+Code pull requests are not the preferred path. Human-written code-only pull requests are not accepted, and agent-written pull requests need a tested reproduction prompt plus human sanity-checking.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the current workflow.
+
+## Using the libraries
+
+### Option 1: single-file libraries
+
+Use this path when you want to vendor one library without adopting the whole repository.
+
+1. Download a release header from the table below or from the [latest release](https://github.com/Pagghiu/SaneCppLibraries/releases/latest).
+2. Include `SaneCppLIBRARY.h` from your headers.
+3. In one `.cpp` file, define `SANE_CPP_IMPLEMENTATION` before including the same header.
+
+You can also generate single-file headers from the current branch using the [Single File Library browser](https://pagghiu.github.io/SaneCppLibraries/reference/doxygen/page_single_file_libs.html).
+
+### Option 2: repository checkout
+
+Use this path when you want several libraries together or want to keep the source tree available.
+
+1. Clone the repository and add it as a subfolder of your project.
+2. Add [SC.cpp](SC.cpp) to your build system.
+3. Include the headers for the libraries you use.
+
+See [Building (user)](https://pagghiu.github.io/SaneCppLibraries/guides/building-user/) for platform-specific system libraries and linker details.
+
+### Option 3: SC::Build
+
+Use the repository build tooling when you want examples, tests, native builds, cross targets, or package-managed toolchains.
+
+- [SC::Build guide](https://pagghiu.github.io/SaneCppLibraries/guides/build/)
+- [External SC::Build bootstrap](https://pagghiu.github.io/SaneCppLibraries/guides/build-external/)
+- [Contributor build guide](https://pagghiu.github.io/SaneCppLibraries/guides/building-contributor/)
+
+## Libraries
+
+Libraries are designed to stay independent and work well as [single-file libraries](https://pagghiu.github.io/SaneCppLibraries/reference/doxygen/page_single_file_libs.html). The [dependency graph](https://pagghiu.github.io/SaneCppLibraries/reference/doxygen/page_dependencies.html) is part of the public project documentation.
+
+Status legend:
+
+- 🟥 Draft: incomplete, work in progress, works on basic test cases
+- 🟨 MVP: a minimum useful feature set has been implemented
+- 🟩 Usable: a reasonable set of useful features has been implemented
+
+Library | Description | Single File
+:--|:--|:--
+[Async](https://pagghiu.github.io/SaneCppLibraries/libraries/async/) | 🟨 Async I/O for files, sockets, timers, processes, filesystem events, and tasks | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppAsync.h)
+[Async Streams](https://pagghiu.github.io/SaneCppLibraries/libraries/async-streams/) | 🟨 Concurrently read, write, and transform byte streams | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppAsyncStreams.h)
+[Await](https://pagghiu.github.io/SaneCppLibraries/libraries/await/) | 🟨 C++20 coroutine layer over Async | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppAwait.h)
+[Containers](https://pagghiu.github.io/SaneCppLibraries/libraries/containers/) | 🟨 Generic containers such as `SC::Vector`, `SC::SmallVector`, and `SC::Array` | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppContainers.h)
+[Containers Reflection](https://pagghiu.github.io/SaneCppLibraries/libraries/containers-reflection/) | 🟨 Container specializations for Reflection and Serialization | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppContainersReflection.h)
+[File](https://pagghiu.github.io/SaneCppLibraries/libraries/file/) | 🟩 Synchronous disk file I/O | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppFile.h)
+[File System](https://pagghiu.github.io/SaneCppLibraries/libraries/file-system/) | 🟩 File and directory operations such as copy, remove, and rename | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppFileSystem.h)
+[File System Iterator](https://pagghiu.github.io/SaneCppLibraries/libraries/file-system-iterator/) | 🟩 Enumerates files and directories inside a path | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppFileSystemIterator.h)
+[File System Watcher](https://pagghiu.github.io/SaneCppLibraries/libraries/file-system-watcher/) | 🟩 Filesystem notifications for add, remove, rename, and modify events | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppFileSystemWatcher.h)
+[Foundation](https://pagghiu.github.io/SaneCppLibraries/libraries/foundation/) | 🟩 Primitive types, asserts, compiler macros, `Function`, `Span`, and `Result` | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppFoundation.h)
+[Hashing](https://pagghiu.github.io/SaneCppLibraries/libraries/hashing/) | 🟩 Computes `MD5`, `SHA1`, and `SHA256` hashes for byte streams | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppHashing.h)
+[Http](https://pagghiu.github.io/SaneCppLibraries/libraries/http/) | 🟥 HTTP parser, client, server, and WebSocket support | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppHttp.h)
+[Http Client](https://pagghiu.github.io/SaneCppLibraries/libraries/http-client/) | 🟥 Streaming-first HTTP client with native OS backends | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppHttpClient.h)
+[Memory](https://pagghiu.github.io/SaneCppLibraries/libraries/memory/) | 🟩 Custom allocators, virtual memory, buffers, and segments | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppMemory.h)
+[Plugin](https://pagghiu.github.io/SaneCppLibraries/libraries/plugin/) | 🟨 Minimal dependency-based plugin system with hot reload | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppPlugin.h)
+[Process](https://pagghiu.github.io/SaneCppLibraries/libraries/process/) | 🟩 Creates child processes and redirects their input and output | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppProcess.h)
+[Reflection](https://pagghiu.github.io/SaneCppLibraries/libraries/reflection/) | 🟩 Describes C++ types at compile time for serialization | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppReflection.h)
+[SerialPort](https://pagghiu.github.io/SaneCppLibraries/libraries/serial-port/) | 🟨 Serial port configuration and handling | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppSerialPort.h)
+[Serialization Binary](https://pagghiu.github.io/SaneCppLibraries/libraries/serialization-binary/) | 🟨 Binary serialization using Reflection | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppSerializationBinary.h)
+[Serialization Text](https://pagghiu.github.io/SaneCppLibraries/libraries/serialization-text/) | 🟨 Text serialization using Reflection | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppSerializationText.h)
+[Socket](https://pagghiu.github.io/SaneCppLibraries/libraries/socket/) | 🟨 Synchronous socket networking and DNS lookup | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppSocket.h)
+[Strings](https://pagghiu.github.io/SaneCppLibraries/libraries/strings/) | 🟩 String formatting, conversion, and manipulation for UTF-8 and UTF-16 | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppStrings.h)
+[Testing](https://pagghiu.github.io/SaneCppLibraries/libraries/testing/) | 🟨 Simple testing framework used by the other libraries | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppTesting.h)
+[Threading](https://pagghiu.github.io/SaneCppLibraries/libraries/threading/) | 🟩 Atomics, threads, mutexes, semaphores, barriers, rw-locks, and conditions | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppThreading.h)
+[Time](https://pagghiu.github.io/SaneCppLibraries/libraries/time/) | 🟨 Relative, absolute, and high-resolution time handling | [Download](https://github.com/Pagghiu/SaneCppLibraries/releases/latest/download/SaneCppTime.h)
 
 <picture>
   <img alt="Sane C++ Libraries dependencies" src="https://pagghiu.github.io/images/dependencies/SaneCppLibrariesDependencies.svg">
 </picture>
 
-## How to use Sane C++ Libraries in your project
+## Constraints
 
-### Option 1: use single file libraries
-1. Obtain a specific library: 
-    - Downloading it from the above table or from the [Latest Release](https://github.com/Pagghiu/SaneCppLibraries/releases/latest) page 
-    - Assembling it from current `main` branch using the [Single File Library](https://pagghiu.github.io/SaneCppLibraries/page_single_file_libs.html) browser app
-2. `#include SaneCppLIBRARY.h` in your headers
-3. `#define SANE_CPP_IMPLEMENTATION` + `#include "SaneCppLIBRARY.h"` in one of your `.cpp` files
+These constraints are part of the project identity and are especially important when code is generated or regenerated by agents:
 
-See [Building (user)](https://pagghiu.github.io/SaneCppLibraries/page_building_user.html) for details on the (system) libraries to link.  
+- Keep library boundaries explicit.
+- Avoid accidental internal dependencies.
+- Prefer caller-owned memory and explicit error handling.
+- Avoid hidden dynamic allocations in normal library code.
+- Keep platform-specific code isolated.
+- Add focused tests for new behavior when practical.
 
-### Option 2: use all libraries together
-1. Clone the entire repo and add it as subfolder of your project
-2. Add [SC.cpp](SC.cpp) to your build system of choice
-3. Include any public header (`Libraries/[Library]/*.h`)
+Allocation notes:
 
-See [Building (user)](https://pagghiu.github.io/SaneCppLibraries/page_building_user.html) for details on the (system) libraries to link.
+- Most libraries are designed to work inside user-provided memory buffers.
+- APIs report allocation failures explicitly, usually through `SC::Result`.
+- [Memory](https://pagghiu.github.io/SaneCppLibraries/libraries/memory/) and [Containers](https://pagghiu.github.io/SaneCppLibraries/libraries/containers/) allocate by default, but can also work with fixed memory buffers.
+- [Await](https://pagghiu.github.io/SaneCppLibraries/libraries/await/) uses caller-owned fixed buffers by default; virtual memory, `malloc` / `free`, and polymorphic allocators are explicit opt-in modes.
+- Third-party containers, including `std::` containers, are supported. See [InteropSTL](Tests/InteropSTL) for an example.
+
+## When using coding agents
+
+`README.md` is written for humans. If you ask an agent to work on this repository, point it at the project instructions first:
+
+1. Read [AGENTS.md](AGENTS.md).
+2. Read [CONTRIBUTING.md](CONTRIBUTING.md).
+3. Read the relevant library page and local `AGENTS.md` files before editing code.
+4. Name the affected library, tool, or platform.
+5. Preserve the constraints above.
+6. Run focused validation and report what was not tested.
+
+## Documentation
+
+- [Website](https://pagghiu.github.io/SaneCppLibraries/)
+- [Guides](https://pagghiu.github.io/SaneCppLibraries/guides/)
+- [Library catalog](https://pagghiu.github.io/SaneCppLibraries/libraries/)
+- [Reference documentation](https://pagghiu.github.io/SaneCppLibraries/reference/doxygen/)
+- [Coverage](https://pagghiu.github.io/SaneCppLibraries/reference/doxygen/coverage/)
+- [DeepWiki/SaneCppLibraries](https://deepwiki.com/Pagghiu/SaneCppLibraries)
 
 ## Examples
 
-- [SCTest Suite](Tests/Libraries) showcases most functionalities of all libraries.
-  Check [Building (contributor)](https://pagghiu.github.io/SaneCppLibraries/page_building_contributor.html) for details.
-- [Documentation](https://pagghiu.github.io/SaneCppLibraries/libraries.html) page of each library embeds some examples and / or code snippets.
-- [Examples](https://pagghiu.github.io/SaneCppLibraries/page_examples.html) showcases some basic examples like an `AsyncWebServer` and a more advanced `SCExample` an [Async](https://pagghiu.github.io/SaneCppLibraries/library_async.html) event loop integration with a GUI and usage of [Plugin](https://pagghiu.github.io/SaneCppLibraries/library_plugin.html).
-- [Tools](https://pagghiu.github.io/SaneCppLibraries/page_tools.html) is a collection of repository / code automation tools built using libraries themselves
-  - Includes a fully self-hosted [SC::Build](https://pagghiu.github.io/SaneCppLibraries/page_build.html) build system where builds are imperatively described using C++ code, can generate XCode / Visual Studio / Make projects, and can also build directly through a native backend on macOS, Linux, and Windows.
-
-## No Allocations (*)
-
-- All libraries are designed to work inside user-provided memory buffers and can be used without dynamic memory allocation.
-- All libraries return error codes when running out of such memory buffers (except in containers assignment operators, where they will assert).
-- [Memory](https://pagghiu.github.io/SaneCppLibraries/library_memory.html) and [Containers](https://pagghiu.github.io/SaneCppLibraries/library_containers.html) are the only ones that **will allocate**  by default, even if they support working inside fixed memory buffers (**Opt-out allocation**).
-- [Await](https://pagghiu.github.io/SaneCppLibraries/library_await.html) uses by default caller-owned fixed buffers, while virtual memory, malloc/free, and polymorphic allocators are explicit opt-in modes (**Opt-in allocation**).
-- Third-party container classes, including `std::` ones, are fully supported (see [InteropSTL](Tests/InteropSTL) for an example).
-- [Memory](https://pagghiu.github.io/SaneCppLibraries/library_memory.html) and [Containers](https://pagghiu.github.io/SaneCppLibraries/library_containers.html) are provided for convenience if user prefers them to `std::` or to any other equivalent containers library, and they're totally optional.
-
-## Documentation
-[Documentation](https://pagghiu.github.io/SaneCppLibraries/index.html) is automatically generated using Doxygen and updated at every commit to `main` branch.
-
-## Getting in touch
-
-- [Sane Coding Discord](https://discord.gg/tyBfFp33Z6)  
-- [X](https://x.com/pagghiu_) `@pagghiu_`
-- [GitHub Discussion](https://github.com/Pagghiu/SaneCppLibraries/discussions)
+- [SCTest Suite](Tests/Libraries) covers most library functionality.
+- [Examples](https://pagghiu.github.io/SaneCppLibraries/guides/examples/) includes examples such as `AsyncWebServer` and the more advanced `SCExample`.
+- [Tools](https://pagghiu.github.io/SaneCppLibraries/guides/tools/) documents repository and code automation tools built with the libraries themselves.
 
 ## Contributing
 
-Contributions are issue-first and agent-friendly; see [CONTRIBUTING.md](CONTRIBUTING.md) for the current workflow.
+Contributions are issue-first and agent-friendly.
 
-- [Principles](https://pagghiu.github.io/SaneCppLibraries/page_principles.html) 
-- [Coding Style](https://pagghiu.github.io/SaneCppLibraries/page_coding_style.html)
+Start here:
+
 - [CONTRIBUTING.md](CONTRIBUTING.md)
+- [Principles](https://pagghiu.github.io/SaneCppLibraries/guides/principles/)
+- [Coding Style](https://pagghiu.github.io/SaneCppLibraries/guides/coding-style/)
 
-## License
+## Community
 
-Sane C++ Libraries are licensed under the MIT License, see [LICENSE.txt](LICENSE.txt) for more information.
-
-## Videos
-
-On this [YouTube Channel](https://www.youtube.com/@Pagghiu) there are some videos showing bits of the development process.
+- [Sane Coding Discord](https://discord.gg/tyBfFp33Z6)
+- [X](https://x.com/pagghiu_) `@pagghiu_`
+- [GitHub Discussions](https://github.com/Pagghiu/SaneCppLibraries/discussions)
+- [YouTube](https://www.youtube.com/@Pagghiu)
 
 ## Blog posts
 
-On [Sane Coding Blog](https://pagghiu.github.io) there is a series of posts about this project.
+On the [Sane Coding Blog](https://pagghiu.github.io) there is a series of posts about this project.
 
 Relevant yearly posts:
 
-- [Blog Post - Sane C++ Libraries (Open Sourcing)](https://pagghiu.github.io/site/blog/2023-12-23-SaneCppLibrariesRelease.html)
-- [Blog Post - 1st Year of Sane C++ Libraries](https://pagghiu.github.io/site/blog/2024-12-23-SaneCpp1Year.html)
-- [Blog Post - 2nd year of Sane C++ Libraries](https://pagghiu.github.io/site/blog/2025-12-23-SaneCpp2Year.html)
+- [Sane C++ Libraries: open sourcing](https://pagghiu.github.io/site/blog/2023-12-23-SaneCppLibrariesRelease.html)
+- [1st year of Sane C++ Libraries](https://pagghiu.github.io/site/blog/2024-12-23-SaneCpp1Year.html)
+- [2nd year of Sane C++ Libraries](https://pagghiu.github.io/site/blog/2025-12-23-SaneCpp2Year.html)
 
-## External
-- [DeepWiki/SaneCppLibraries](https://deepwiki.com/Pagghiu/SaneCppLibraries) (AI-guided walkthrough of the project)
+## License
+
+Sane C++ Libraries are licensed under the MIT License. See [LICENSE.txt](LICENSE.txt) for more information.


### PR DESCRIPTION
## Summary
- refresh the README around the current agentic development workflow
- keep documentation and coverage checks in SaneCppLibraries CI
- stop deploying GitHub Pages directly from SaneCppLibraries
- trigger Pagghiu/pagghiu.github.io-source after successful main documentation CI

## Notes
The website source repository now owns the final pagghiu.github.io publication step. SaneCppLibraries remains responsible for proving that Doxygen and coverage generation still work.